### PR TITLE
update autopromote requirements

### DIFF
--- a/autopromote/requirements.txt
+++ b/autopromote/requirements.txt
@@ -4,8 +4,8 @@ certifi==2018.1.18
 chardet==3.0.4
 idna==2.6
 python-dateutil==2.6.1
-requests==2.18.4
 six==1.11.0
 slacker==0.9.60
-urllib3==1.22
 python-dotenv==0.10.2
+urllib3>=1.24.2
+requests>=2.20.0


### PR DESCRIPTION
Update requirements for autopromote. Both these libraries have vulnerabilities in previous version.