### PR TITLE
expand filter object before use

### DIFF
--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -265,7 +265,7 @@ def main():
                 get_pkgs(os.path.join(CONFIG["munki_repo"], "pkgsinfo")),
             ),
         )
-        promotions = promote_pkgs(pkgs)
+        promotions = promote_pkgs([p for p in pkgs])
         logger.debug("Calling makecatalogs...")
         subprocess.call(["/usr/local/munki/makecatalogs", CONFIG["munki_repo"]], stdout=open(os.devnull, 'w'))
     except Exception as e:


### PR DESCRIPTION
Python 3 returns a filter object: https://stackoverflow.com/questions/13638898/how-to-use-filter-map-and-reduce-in-python-3

This update expands our filter to a normal list before we begin processing.