### PR TITLE
Move platform guard to default recipe

### DIFF
--- a/chef/cookbooks/cpe_zoom/recipes/default.rb
+++ b/chef/cookbooks/cpe_zoom/recipes/default.rb
@@ -8,4 +8,6 @@
 # This product includes software developed by
 # ZenPayroll, Inc., dba Gusto (http://www.gusto.com/).
 
+return unless node.macos?
+
 cpe_zoom 'Configure zoom.us'

--- a/chef/cookbooks/cpe_zoom/resources/cpe_zoom.rb
+++ b/chef/cookbooks/cpe_zoom/resources/cpe_zoom.rb
@@ -22,7 +22,6 @@ default_action :config
 require 'plist'
 
 action :config do
-  return unless node.macos?
   return unless node['cpe_zoom']['configure']
 
   prefs = node['cpe_zoom']['client_preferences'].reject { |_k, v| v.nil? }


### PR DESCRIPTION
This PR will move the `return unless node.macos?` block into the recipe so the non-macOS clients bail immediately. Also, this change follows suit with the pattern in Facebook. Pinterest, and Uber's open-source cookbooks.