### PR TITLE
Move `cpe_zoom` platform guard; add guards in `cpe_activedirectory`, `cpe_yo`

### DIFF
--- a/chef/cookbooks/cpe_activedirectory/recipes/default.rb
+++ b/chef/cookbooks/cpe_activedirectory/recipes/default.rb
@@ -11,4 +11,6 @@
 # ZenPayroll, Inc., dba Gusto (http://www.gusto.com/).
 #
 
+return unless node.macos?
+
 cpe_activedirectory 'Apply dsconfigad commands'

--- a/chef/cookbooks/cpe_yo/recipes/default.rb
+++ b/chef/cookbooks/cpe_yo/recipes/default.rb
@@ -44,6 +44,8 @@
 #   at DateTime.parse('Jan 19 2038 03:14:07')
 # end
 
+return unless node.macos?
+
 cpe_yo 'Configure Yo scheduler' do
   action :configure
   only_if { node['cpe_yo']['configure'] }

--- a/chef/cookbooks/cpe_zoom/recipes/default.rb
+++ b/chef/cookbooks/cpe_zoom/recipes/default.rb
@@ -8,4 +8,6 @@
 # This product includes software developed by
 # ZenPayroll, Inc., dba Gusto (http://www.gusto.com/).
 
+return unless node.macos?
+
 cpe_zoom 'Configure zoom.us'

--- a/chef/cookbooks/cpe_zoom/resources/cpe_zoom.rb
+++ b/chef/cookbooks/cpe_zoom/resources/cpe_zoom.rb
@@ -22,7 +22,6 @@ default_action :config
 require 'plist'
 
 action :config do
-  return unless node.macos?
   return unless node['cpe_zoom']['configure']
 
   prefs = node['cpe_zoom']['client_preferences'].reject { |_k, v| v.nil? }


### PR DESCRIPTION
Same as #4 but now GPG-signed, sealed, and delivered:
![image](https://user-images.githubusercontent.com/24925402/74011396-06ff5c80-4988-11ea-92bf-6d34fbe70f35.png)

This PR will move the `return unless node.macos?` guard block into the recipe so the non-macOS clients bail immediately. Also, this pull request will implement platform guards in `cpe_activedirectory` and `cpe_yo`. 

Proposed changes follows suit with the pattern in Facebook. Pinterest, and Uber's open-source cookbooks.