### PR TITLE
refactor configure block and better logging

### DIFF
--- a/chef/cookbooks/cpe_activedirectory/README.md
+++ b/chef/cookbooks/cpe_activedirectory/README.md
@@ -8,6 +8,11 @@ Requirements
 ------------
 macOS
 
+Notes
+------------
+Attempting to bind with the profile_resource and simultaneously run the
+configure resource will result in the profile failing. The cookbook
+will warn and return if you attempt to do this configuration.
 
 Attributes
 ----------

--- a/chef/cookbooks/cpe_activedirectory/attributes/default.rb
+++ b/chef/cookbooks/cpe_activedirectory/attributes/default.rb
@@ -24,7 +24,7 @@
 default['cpe_activedirectory'] = {
   'bind' => false,
   'bind_ldap_check_hostname' => nil, # Example: 'ldaps.ad.domain.tld'
-  'bind_ldap_check_port' => '636', # Example: '389' if you are crazy
+  'bind_ldap_check_port' => 636, # Example: 389 if you are crazy
   'bind_method' => 'profile_resource', # 'profile_resource' or 'execute_resource'
   'bind_options' => {
     'ADOrganizationalUnit' => nil, # Example: 'OU=computers,DC=ad,DC=domain,DC=tld'


### PR DESCRIPTION
I noticed that the `ruby_block` is not idempotent before merging it internally, so if you are trying to get to 0 resources updated at the end of your run, this makes it impossible.

After thinking through the code, I realized it ultimately falls into ensuring the guard is run at runtime. This greatly reduces it's complexity and functions similarly.

I did drop the warning about `unsupported` keys, because that's not going to be possible with the guard and I think it outweighs the need for someone to just realize this (since it's documented anyway in the attributes file).

This also bails on the `configure` block and warns if it's used in conjunction with installing via profile, since we found out it fails.