### PR TITLE
Fix git runs in autopkg_tools

### DIFF
--- a/autopkg/autopkg_tools.py
+++ b/autopkg/autopkg_tools.py
@@ -113,7 +113,7 @@ def git_run(cmd):
         print("Running " + cmd)
 
     try:
-        result = subprocess.run(cmd, shell=True, cwd=MUNKI_REPO, capture_output=True)
+        result = subprocess.run(" ".join(cmd), shell=True, cwd=MUNKI_REPO, capture_output=True)
     except subprocess.CalledProcessError as e:
         print(e.stderr)
         raise e


### PR DESCRIPTION
If you look at `result` you can confirm stdout is the output of running git with no args:

```
CompletedProcess(args=['git', 'rev-parse', '--abbrev-ref', 'HEAD'], stdout=b"usage: git [--version] [--help] [-C <path>] [-c <name>=<value>]\n           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]\n           [-p | --paginate | -P | --no-pager] [--no-replace- stderr=b'')
```

This patch instead passes args as a string.
