### PR TITLE
use creation_date as last_promoted date on new packages, if possible

### DIFF
--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -300,7 +300,9 @@ def promote_pkg(current_plist, path):
         promotion_due = False
     else:
         channel_shifted = promotion_period * get_channel_multiplier(plist)
-        logger.debug(f"Channel-shifted promotion period for {fullname} is {channel_shifted}")
+        logger.debug(
+            f"Channel-shifted promotion period for {fullname} is {channel_shifted}"
+        )
         promotion_due = (arrow.now() - last_promoted).days >= channel_shifted
 
     if not promotion_due:

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -300,7 +300,7 @@ def promote_pkg(current_plist, path):
         promotion_due = False
     else:
         channel_shifted = promotion_period * get_channel_multiplier(plist)
-        logger.deubg(f"Channel-shifted promotion period for {fullname} is {channel_shifted}")
+        logger.debug(f"Channel-shifted promotion period for {fullname} is {channel_shifted}")
         promotion_due = (arrow.now() - last_promoted).days >= channel_shifted
 
     if not promotion_due:

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -299,9 +299,9 @@ def promote_pkg(current_plist, path):
     if last_promoted is None:
         promotion_due = False
     else:
-        promotion_due = (arrow.now() - last_promoted).days >= (
-            promotion_period * get_channel_multiplier(plist)
-        )
+        channel_shifted = promotion_period * get_channel_multiplier(plist)
+        logger.deubg(f"Channel-shifted promotion period for {fullname} is {channel_shifted}")
+        promotion_due = (arrow.now() - last_promoted).days >= channel_shifted
 
     if not promotion_due:
         return promoted, result


### PR DESCRIPTION
This PR seeks to respect the promotion days defined for a new package by treating autopkg's `creation_date` as the `last_promoted` date.