### PR TITLE
Channels top level key

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ CPE attributes-API patterned chef cookbooks which support user/team/node customi
 
 Our node functions. We recommend keeping a cpe_utils/node_functions folder, and including multiple repos' node_functions file (Uber, Facebook) in a predetermined order.
 
-## Autopromote
+## autopkg
+
+An example Github actions pipeline for running autopkg.
+
+## autopromote
 
 This script promotes munki packages between a set of json-configured catalogs. It can be adapted to any munki setup, so long as it has write access to the pkgsinfo folder. If you use a version controlled munki, you may want to remove the makecatalogs bits.
 

--- a/autopromote/README.md
+++ b/autopromote/README.md
@@ -55,11 +55,11 @@ __channels__: Channels allow one to specify a faster or slower promotion schedul
 You may add a package to a channel by adding a channel key to the pkginfo metadata dict. If no channel is specified, or if a non-float/int value is specified, the channel modifier is always 1. A package in the "slow" channel would have this in its pkginfo:
 
 ```xml
-<key>_metadata</key>
+<key>pkginfo</key>
 	<dict>
 	   <key>channel</key>
           <string>slow</string>
 	</dict>
 ```
 
-If you're using [AutoPkg](https://github.com/autopkg/autopkg) you can configure this in your recipe override, so all versions of a package enter the same channel.
+If you're using [AutoPkg](https://github.com/autopkg/autopkg) you can configure this in your recipe override, so all versions of a package enter the same channel. Simple add the above xml to your package override.

--- a/autopromote/README.md
+++ b/autopromote/README.md
@@ -62,4 +62,4 @@ You may add a package to a channel by adding a channel key to the pkginfo metada
 	</dict>
 ```
 
-If you're using [AutoPkg](https://github.com/autopkg/autopkg) you can configure this in your recipe override, so all versions of a package enter the same channel. Simple add the above xml to your package override.
+If you're using [AutoPkg](https://github.com/autopkg/autopkg) you can configure this in your recipe override, so all versions of a package enter the same channel. Add the above xml to your package override.

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -219,7 +219,7 @@ def get_next_catalog(latest_catalog):
 def get_channel_multiplier(plist):
     """Retrieve the float multiplier for plist's channel. Returns multiplier or 1"""
 
-    channel = plist.get("_metadata", {}).get("channel")
+    channel = plist.get("channel")
     if channel is None:
         return 1.0
 


### PR DESCRIPTION
This PR:

-> Treats "channel" as a top-level pkginfo key. Testing indicates that munki safely ignores top-level keys that are not supported. By making it such, we allow the key to be defined in pkginfo files.

-> Updates the main readme to reference the autopkg pipeline project; adjusts the example channel configuration in autopromote's readme.