### PR TITLE
encapsulate pkg/pkginfo paths in quotes to allow for spaces

### DIFF
--- a/autopkg/autopkg_tools.py
+++ b/autopkg/autopkg_tools.py
@@ -151,8 +151,8 @@ def handle_recipe(recipe):
     if recipe.results["imported"]:
         checkout(recipe.branch)
         for imported in recipe.results["imported"]:
-            git_run(["add", f"pkgs/{ imported['pkg_repo_path'] }"])
-            git_run(["add", f"pkgsinfo/{ imported['pkginfo_path'] }"])
+            git_run(["add", f"'pkgs/{ imported['pkg_repo_path'] }'"])
+            git_run(["add", f"'pkgsinfo/{ imported['pkginfo_path'] }'"])
 
         git_run(
             ["commit", "-m", f"'Updated { recipe.name } to { recipe.updated_version }'"]


### PR DESCRIPTION
From a debug run:

```
Running git add pkgs/apps/ZoomIT/ZoomIT-5.2.3 (45131.0907).pkg
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `git add pkgs/apps/ZoomIT/ZoomIT-5.2.3 (45131.0907).pkg'
Running git add pkgsinfo/apps/ZoomIT/ZoomIT-5.2.3 (45131.0907).plist
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `git add pkgsinfo/apps/ZoomIT/ZoomIT-5.2.3 (45131.0907).plist'
```

Whoops!