### PR TITLE
Replace #Hash.reject with #Hash.compact

### DIFF
--- a/chef/cookbooks/cpe_activedirectory/resources/cpe_activedirectory.rb
+++ b/chef/cookbooks/cpe_activedirectory/resources/cpe_activedirectory.rb
@@ -145,7 +145,7 @@ action_class do # rubocop:disable Metrics/BlockLength
     bind_options = node['cpe_activedirectory']['bind_options']
     node['cpe_activedirectory']['options'].each do |root_key, root_subkeys|
       next if root_subkeys.all?(NilClass)
-      root_subkeys.reject { |_k, v| v.nil? }.each do |key, value|
+      root_subkeys.compact.each do |key, value|
         cmd = "/usr/sbin/dsconfigad -#{key} #{shell_format(value)}"
         if node['cpe_activedirectory']['what_if_execution']
           Chef::Log.info("Would have run '#{cmd}'")

--- a/chef/cookbooks/cpe_ublock/resources/cpe_ublock.rb
+++ b/chef/cookbooks/cpe_ublock/resources/cpe_ublock.rb
@@ -23,7 +23,7 @@ resource_name :cpe_ublock
 default_action :run
 
 action :run do
-  prefs = node['cpe_ublock']['adminSettings'].reject { |_k, v| v.nil? }
+  prefs = node['cpe_ublock']['adminSettings'].compact
   prefix = node['cpe_profiles']['prefix']
   organization = node['organization'] || 'Gusto'
   return if prefs.empty?

--- a/chef/cookbooks/cpe_yo/resources/cpe_yo.rb
+++ b/chef/cookbooks/cpe_yo/resources/cpe_yo.rb
@@ -228,7 +228,7 @@ action_class do
   def create_files
     args = FILE_ARGS
       .map { |arg| [arg, new_resource.send(arg)] }.to_h
-      .reject { |_, val| val.nil? }
+      .compact
     configure_base_directories unless args.empty?
 
     args.each do |arg, val|
@@ -258,7 +258,7 @@ action_class do
 
   def command_line_arguments
     @cli_args ||= arguments_hash
-      .reject { |_, val| val.nil? }
+      .compact
       .sort_by { |arg, val| arg }
       .map { |arg, val| shell_format(arg, val) }
       .join(' ')


### PR DESCRIPTION
This PR will do one thing: Replace all instances of #Hash.reject { |_k, v | v.nil? } with #Hash.compact.

This has been shown (chef/chef#10601) to increase speed by a reasonable amount and is a bit more simple (IMHO).

Tested this locally with Chef Solo and -- with a sample size of 4x runs -- our run_list went from an average run time of 30s (using .reject) to 24s (using .compact).