### PR TITLE
Bugfix for cpe_ad on specific vers of chef-client

### DIFF
--- a/chef/cookbooks/cpe_activedirectory/resources/cpe_activedirectory.rb
+++ b/chef/cookbooks/cpe_activedirectory/resources/cpe_activedirectory.rb
@@ -12,7 +12,7 @@
 #
 
 resource_name :cpe_activedirectory
-provides :cpe_activedirectory
+provides :cpe_activedirectory, :os => 'darwin'
 default_action :run
 
 action :run do


### PR DESCRIPTION
Chef client v16.1 or 16.2 had a bug whereby one must supply `:os` or it will blow-up Chef runs. Kind of annoying to keep it in there for this minor bug but I don't think there's any harm in doing so.