### PR TITLE
Adding recipe verification and ability to run single recipes

### DIFF
--- a/autopkg/autopkg_tools.py
+++ b/autopkg/autopkg_tools.py
@@ -15,6 +15,7 @@ DEBUG = False
 SLACK_WEBHOOK = os.environ.get("SLACK_WEBHOOK_TOKEN", None)
 MUNKI_REPO = os.path.join(os.getenv("GITHUB_WORKSPACE", "/tmp/"), "munki_repo")
 OVERRIDES_DIR = os.path.relpath("overrides/")
+RECIPE_TO_RUN = os.environ.get("RECIPE", None)
 
 
 class Recipe(object):
@@ -276,15 +277,19 @@ def main():
     global DEBUG
     DEBUG = bool(opts.debug)
 
-    if not opts.list:
-        print("Recipe list not provided!")
-        sys.exit(1)
-
     no_updates = []
 
-    for recipe in parse_recipes(opts.list):
-        result = handle_recipe(recipe)
-        slack_alert(recipe, opts)
+    if RECIPE_TO_RUN:
+        for recipe in parse_recipes(RECIPE_TO_RUN):
+            result = handle_recipe(recipe)
+            slack_alert(recipe, opts)
+    else:
+        if not opts.list:
+            print("Recipe list not provided!")
+            sys.exit(1)
+        for recipe in parse_recipes(opts.list):
+            result = handle_recipe(recipe)
+            slack_alert(recipe, opts)
 
     if opts.icons:
         import_icons()

--- a/autopkg/autopkg_tools.py
+++ b/autopkg/autopkg_tools.py
@@ -167,16 +167,22 @@ def parse_recipes(file_path):
     recipe_list = []
     ext = os.path.splitext(file_path)[1]
 
-    if ext == ".json":
-        parser = json.load
-    elif ext == ".plist":
-        parser = plistlib.load
+    ## Added this section so that we can run individual recipes
+    if ext == ".munki":
+        recipe_list.append(file_path + ".recipe")
+    elif ext == ".recipe":
+        recipe_list.append(file_path)
     else:
-        print(f'Invalid run list extension "{ ext }" (expected plist or json)')
-        sys.exit(1)
+        if ext == ".json":
+            parser = json.load
+        elif ext == ".plist":
+            parser = plistlib.load
+        else:
+            print(f'Invalid run list extension "{ ext }" (expected plist or json)')
+            sys.exit(1)
 
-    with open(file_path, "rb") as f:
-        recipe_list = parser(f)
+        with open(file_path, "rb") as f:
+            recipe_list = parser(f)
 
     return map(Recipe, recipe_list)
 

--- a/autopkg/autopkg_tools.py
+++ b/autopkg/autopkg_tools.py
@@ -211,7 +211,7 @@ def handle_recipe(recipe, opts):
 def parse_recipes(recipes):
     recipe_list = []
     ## Added this section so that we can run individual recipes
-    if isinstance(recipes, list):
+    if RECIPE_TO_RUN:
         for recipe in recipes:
             ext = os.path.splitext(recipe)[1]
             if ext != ".recipe":
@@ -344,7 +344,7 @@ def main():
 
     failures = []
 
-    recipes = RECIPE_TO_RUN if RECIPE_TO_RUN else opts.list if opts.list else None
+    recipes = RECIPE_TO_RUN.split(", ") if RECIPE_TO_RUN else opts.list if opts.list else None
     if recipes is None:
         print("Recipe --list or RECIPE_TO_RUN not provided!")
         sys.exit(1)

--- a/autopkg/autopkg_tools.py
+++ b/autopkg/autopkg_tools.py
@@ -357,14 +357,12 @@ def main():
                 failures.append(recipe)
     if not opts.disable_verification:
         if failures:
-            title_file=open("pull_request_title","a+")
-            title_file.write("fix: Update trust for")
-            body_file=open("pull_request_body","a+")
-            for recipe in failures:
-                title_file.write(" " + recipe.name)
-                body_file.write(recipe.results["message"] + "\n")
-            title_file.close()
-            body_file.close()
+            title = " ".join([f"{recipe.name}" for recipe in failures])
+            lines = [f"{recipe.results['message']}\n" for recipe in failures]
+            with open("pull_request_title", "a+") as title_file:
+                title_file.write(f"fix: Update trust for {title}")
+            with open("pull_request_body", "a+") as body_file:
+                body_file.writelines(lines)
 
     if opts.icons:
         import_icons()

--- a/autopkg/workflows/autopkg.yml
+++ b/autopkg/workflows/autopkg.yml
@@ -5,6 +5,11 @@ on:
     types: [started]
   schedule:
     - cron: 00 14 * * 1-5
+  workflow_dispatch: # manually triggered
+    inputs:
+      recipe:
+        description: Recipe to Run (Optional)
+        required: false
 
 jobs:
   AutoPkg:
@@ -65,3 +70,5 @@ jobs:
     - name: Run AutoPkg
       run: |
         python3 autopkg_tools.py -l recipe_list.json
+      env:
+        RECIPE: ${{ github.event.inputs.recipe }}

--- a/autopkg/workflows/autopkg.yml
+++ b/autopkg/workflows/autopkg.yml
@@ -70,5 +70,23 @@ jobs:
     - name: Run AutoPkg
       run: |
         python3 autopkg_tools.py -l recipe_list.json
+        if [ -f pull_request_title ]; then
+        echo "TITLE=$(cat pull_request_title)" >> $GITHUB_ENV
+        echo "BODY<<EOF" >> $GITHUB_ENV
+        cat pull_request_body >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
+        fi
       env:
         RECIPE: ${{ github.event.inputs.recipe }}
+
+    - name: Create Pull Request
+      if: env.TITLE
+      uses: peter-evans/create-pull-request@09b9ac155b0d5ad7d8d157ed32158c1b73689109
+      with:
+        title: ${{ env.TITLE }}
+        body: ${{ env.BODY }}
+        branch: fix_trust_info
+        base: main
+        delete-branch: true
+        commit-message: ${{ env.TITLE }}
+        author: runner <runner@githubactions.local>


### PR DESCRIPTION
This adds in recipe verification before handling the recipe. If the verification fails, the recipe run is skipped. The output of the failed `verify-trust-info -vvv` is sent to Slack if configured.

This also adds the ability to manually run a workflow of a single recipe.