### PR TITLE
Allow triggering AutoPkg run manually

### DIFF
--- a/autopkg/workflows/autopkg.yml
+++ b/autopkg/workflows/autopkg.yml
@@ -1,6 +1,7 @@
 name: Autopkg run
 
 on:
+  workflow_dispatch:
   watch:
     types: [started]
   schedule:


### PR DESCRIPTION
From the Github blog: [GitHub Actions: Manual triggers with workflow_dispatch ](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)