### PR TITLE
Added support for name-version denial

### DIFF
--- a/autopromote/README.md
+++ b/autopromote/README.md
@@ -20,7 +20,7 @@ __catalogs__: A schedule of catalogs. Each should define the number of days a pk
 should live in this catalog, and the next catalog. If `next` is null, the catalog is
 assumed to be the final catalog, no matter the `days` defined.
 
-__denylist__: A list of pkginfos (as defined in their `name` attribute) on which no
+__denylist__: A list of pkginfos (as defined in their `name` or combined `name`-`version` attribute) on which no
 action will ever be taken.
 
 __allowlist__: A list of pkginfos (as defined in their `name` attribute) on which action

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -253,7 +253,7 @@ def promote_pkg(current_plist, path):
     logger.info(f"Considering package {fullname}")
 
     # If the name and name-version are in the deny list AND name is not in the allow list
-    if (name in denylist or name + "-" + version in denylist) and (allowlist and name not in allowlist):
+    if (name in denylist or name + "-" + version in denylist) or (allowlist and name not in allowlist):
 
         # There is a hit, confirm it's not a name hit on a name-version entry
         for denyitem in denylist:

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -252,9 +252,19 @@ def promote_pkg(current_plist, path):
 
     logger.info(f"Considering package {fullname}")
 
-    if name in denylist or name + "-" + version in denylist or (allowlist and name not in allowlist):
-        logger.warn(f"Skipping {fullname}: excluded by allowlist/denylist")
-        return promoted, result
+    # If the name and name-version are in the deny list AND name is not in the allow list
+    if (name in denylist or name + "-" + version in denylist) and (allowlist and name not in allowlist):
+
+        # There is a hit, confirm it's not a name hit on a name-version entry
+        for denyitem in denylist:
+            # If the name is an exacty match and it's not in the allow list
+            if name == denyitem and (allowlist and name not in allowlist):
+                logger.warn(f"Skipping {fullname}: excluded by allowlist/denylist")
+                return promoted, result
+            # If the name-version is an exact match
+            elif name + "-" + version == denyitem:
+                logger.warn(f"Skipping {fullname}-{version}: excluded by denylist")
+                return promoted, result
 
     if (
         CONFIG["enforce_force_install_time"]

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -252,7 +252,7 @@ def promote_pkg(current_plist, path):
 
     logger.info(f"Considering package {fullname}")
 
-    if name in denylist or (allowlist and name not in allowlist):
+    if name in denylist or name + "-" + version in denylist or (allowlist and name not in allowlist):
         logger.warn(f"Skipping {fullname}: excluded by allowlist/denylist")
         return promoted, result
 


### PR DESCRIPTION
adding a package name-version into the `denylist` will stop it from being autopromoted #51 

`"denylist": ["Zoom-5.5.12513.0205"]`

## Test specific version deny

```
>>> name = "Zoom"
>>> fullname = "Zoom"
>>> version = "5.5.12513.0205"
>>> allowlist = ["Spotify"]
>>> denylist = ["Zoom-5.5.12513.0205"]
>>> test_matching()
Skipping Zoom-5.5.12513.0205: excluded by denylist
(False, {'plist': {}, 'from': None, 'to': None, 'fullname': 'fullname'})
```

## Test allowlist different package

```
>>> name = "Spotify"
>>> version = "1.0.0"
>>> allowlist = ["Spotify"]
>>> denylist = ["Zoom-5.5.12513.0205"]
>>> test_matching()
No skip
```

## Test same package new version

```
>>> name = "Zoom"
>>> version = "5.5.12513.99999"
>>> denylist = ["Zoom-5.5.12513.0205"]
>>> test_matching()
No skip
```

~Also fixes the bug where a non empty `allowlist` skips all promotions~