### PR TITLE
Improve allow/deny list

### DIFF
--- a/autopromote/README.md
+++ b/autopromote/README.md
@@ -8,47 +8,74 @@ pkginfo.plist files it promotes.
 
 Autopromote should be run daily, and operates on a promotion schedule of days. Admins may configure a schedule of catalogs, each with a package lifetime and a force install period. Admins may also specify different promotion speeds - channels, specific patch days, and specific force install times.
 
-#### Setup
+### Setup
 
 0. `mkdir .venv && virtualenv .venv && source .venv/bin/active` (py 2.7)
 1. `pip install -r requirements.txt`
-2. `python autopromote.py` (or cron to this effect)
+2. `python3 autopromote.py` (or cron to this effect)
 
-#### Config
+### Config
 
-__catalogs__: A schedule of catalogs. Each should define the number of days a pkginfos
+#### catalogs
+A schedule of catalogs. Each should define the number of days a pkginfos
 should live in this catalog, and the next catalog. If `next` is null, the catalog is
 assumed to be the final catalog, no matter the `days` defined.
 
-__denylist__: A list of pkginfos (as defined in their `name` or combined `name`-`version` attribute) on which no
-action will ever be taken.
+#### denylist
+A dictionary of package_name: package_version_regex to refuse to promote. If the version is
+`null`, promotions for all versions are blocked.
 
-__allowlist__: A list of pkginfos (as defined in their `name` attribute) on which action
-is permitted. This array takes precedence, define a pkginfo here and all others are
-de facto in the denylist.
+To block promoting all versions of BlueJeans and just 5.x versions
+of Zoom, set:
 
-__munki_repo__: full path to the root munki_repo.
+```json
+"denylist": {
+	"Zoom": "5.*",
+	"BlueJeans": null
+}
+```
 
-__fields_to_copy__: when a pkginfo is promoted for the first time (no `last_promoted`
+#### allowlist
+A dictionary of package_name: package_version_regex to refuse to promote. If a
+package_name is set but, promotions which do not match package_version_regex will be blocked.
+
+To allow only 8.x versions of Teleport, set:
+```json
+"allowlist": {
+	"Teleport": "8.*"
+}
+```
+
+#### munki_repo
+ full path to the root munki_repo.
+
+#### fields_to_copy
+ when a pkginfo is promoted for the first time (no `last_promoted`
 value is set), autopromote.py searchs for a previous semantic version of the pkginfo.
 If found, any/all of the fields in this array are copied to the newly promoted pkginfo.
 
-__force_install_days__: If set, all newly promoted pkginfos receive a fresh force_install_after_date matching a T+this value. This is the default, to configure for specific packages use the `catalogs` hash.
+#### force_install_days
+ If set, all newly promoted pkginfos receive a fresh force_install_after_date matching a T+this value. This is the default, to configure for specific packages use the `catalogs` hash.
 
-__patch_tuesday__: An integer, 0-6, which specified the weekday to force force install dates to. For instance, if the force install date is 7 days from now, which falls on a Friday (4), and patch_tuesday is set to Tuesday (1), the force install date will be shifted by 4 days, to 11 days from now, in order to fall on the next Tuesday. This allows admins to automatically create a weekly predictability in their patch cycle.
+#### patch_tuesday
+ An integer, 0-6, which specified the weekday to force force install dates to. For instance, if the force install date is 7 days from now, which falls on a Friday (4), and patch_tuesday is set to Tuesday (1), the force install date will be shifted by 4 days, to 11 days from now, in order to fall on the next Tuesday. This allows admins to automatically create a weekly predictability in their patch cycle.
 
 A patch_tuesday of `null` will preclude any shift of force install dates.
 
-__force_install_time__: The hour and minute, T+force_install_days, at which force install will take
+#### force_install_time
+ The hour and minute, T+force_install_days, at which force install will take
 effect.
 
 Format: `{"hour": int, "minute": int}`
 
-__enforce_force_install_time__: Have you decided 4:30 is a bad force install time? Set this value to true and configure the `force_install_time` to regulate the hour and minute, and, if set, the day (`patch_tuesday`) your package force install datetimes use.
+#### enforce_force_install_time
+ Have you decided 4:30 is a bad force install time? Set this value to true and configure the `force_install_time` to regulate the hour and minute, and, if set, the day (`patch_tuesday`) your package force install datetimes use.
 
-__force_install_denylist__: A list of pkginfos (as defined in their `name` attribute) on which no force_install_after_date will ever be set.
+#### force_install_denylist
+ A list of pkginfos (as defined in their `name` attribute) on which no force_install_after_date will ever be set.
 
-__channels__: Channels allow one to specify a faster or slower promotion schedule for specific packages. This is a dictionary of channel names and an int or float multiplier:
+#### channels
+ Channels allow one to specify a faster or slower promotion schedule for specific packages. This is a dictionary of channel names and an int or float multiplier:
 
 `{"channels": {"slow": 2.5}}` - this channel configuration would cause any packages in the "slow" channel to be promoted 2.5 times *slower*. This is achieved by multiplying the current promotion period by the channel's value. If your promotion period is ten days, setting the slow channel to 2.5 would increase the time between promotions to twenty-five days. For faster promotion schedules, specify a float modifier of less than 1. For example, a multiplier of `0.5` would result in a 2x faster promotion schedule.
 

--- a/autopromote/autopromote.json
+++ b/autopromote/autopromote.json
@@ -24,8 +24,13 @@
 			"force_install_days": 45
 		}
 	},
-	"denylist": [],
-	"allowlist": [],
+	"denylist": {
+		"Zoom": null,
+		"BlueJeans": "5.4.2"
+	},
+	"allowlist": {
+		"Teleport": "8.*"
+	},
 	"remove_old_catalogs": true,
 	"munki_repo": "munki_repo",
 	"fields_to_copy": [

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -4,6 +4,7 @@
 #
 
 import os
+import re
 import sys
 import json
 import arrow

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -64,7 +64,7 @@ def load_deny_and_allow_lists(config):
     def load(*lists):
         for config_item in lists:
             if isinstance(config_item, list):
-                config_item = Dict([k, None] for k in as_defined)
+                config_item = {k: None for k in config_item}
 
             for name, version in config_item.copy().items():
                 version = re.compile(

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -62,18 +62,11 @@ def load_deny_and_allow_lists(config):
     def load(*lists):
         for config_item in lists:
             if isinstance(config_item, list):
-                config_item = Dict([k, {}] for k in as_defined)
+                config_item = Dict([k, None] for k in as_defined)
 
-            for name, values in config_item.items():
-                values = {} if values is None else values
-                assert isinstance(
-                    values, dict
-                ), f"{name} in allow/deny list must have a definition dictionary"
-
-                values["version"] = re.compile(
-                    ".*"
-                    if values.get("version") in [None, "all"]
-                    else values["version"],
+            for name, version in config_item.items():
+                version = re.compile(
+                    ".*" if version in [None, "all"] else version,
                     re.IGNORECASE,
                 )
                 config_item[name] = values

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -22,6 +22,7 @@ from collections import OrderedDict
 
 CONFIG_FILE = "/usr/local/munki/autopromote.json"
 PKGINFOS_PATHS = []
+DEBUG = bool(os.environ.get("DEBUG"))
 
 # Because things get easier if the catalogs are ordered - we don't always need to check "next"
 # in the catalog definition while considering a package for promotion.
@@ -95,6 +96,7 @@ def load_logger(logfile):
     """Returns logger object pointing to stdout or a file, as configured"""
 
     logger = logging.getLogger("autopromote")
+    logger.setLevel(logging.DEBUG if DEBUG else logging.INFO)
     logger.setLevel(logging.DEBUG)
     formatter = logging.Formatter(
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -65,12 +65,12 @@ def load_deny_and_allow_lists(config):
             if isinstance(config_item, list):
                 config_item = Dict([k, None] for k in as_defined)
 
-            for name, version in config_item.items():
+            for name, version in config_item.copy().items():
                 version = re.compile(
                     ".*" if version in [None, "all"] else version,
                     re.IGNORECASE,
                 )
-                config_item[name] = values
+                config_item[name] = version
 
             yield config_item
 

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -254,7 +254,7 @@ def get_channel_multiplier(plist):
 
 
 def permitted(name, version):
-    match = lambda lst: lst.get(name) and lst[name]["version"].match(version)
+    match = lambda lst: lst.get(name) and lst[name].match(version)
     allowed = match(CONFIG["allowlist"])
     denied = match(CONFIG["denylist"])
 

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -10,8 +10,8 @@ import json
 import arrow
 import logging
 import datetime
+import plistlib
 import subprocess
-import plistlib as Plist
 from slacker import Slacker
 from dotenv import load_dotenv
 from xml.parsers.expat import ExpatError
@@ -138,8 +138,9 @@ def safe_read_pkg(pkginfo):
 
     logger.info(f"parsing {pkginfo}")
     try:
-        plist = Plist.readPlist(pkginfo)
-    except (ExpatError, Plist.InvalidFileException) as e:
+        with open(pkginfo, "rb") as f:
+            plist = plistlib.load(f)
+    except (ExpatError, plistlib.InvalidFileException) as e:
         # This is raised if a plist cannot be parsed (generally because its not a plist, but some clutter eg DS_Store)
         logger.warn(f"Failed to parse {pkginfo} because: {repr(e)}")
         plist = None
@@ -393,7 +394,8 @@ def promote_pkgs(pkginfos):
         if promoted:
             promotions[result["fullname"]] = result
 
-        Plist.writePlist(result["plist"], pkginfo)
+        with open(pkginfo, "wb") as f:
+            plistlib.dump(result["plist"], f)
 
     return promotions
 

--- a/autopromote/requirements.txt
+++ b/autopromote/requirements.txt
@@ -2,11 +2,13 @@ arrow==0.12.1
 backports.functools-lru-cache==1.5
 certifi==2018.1.18
 chardet==3.0.4
+charset-normalizer==2.0.4
 idna==2.6
+packaging==19.0
+pyparsing==2.4.7
 python-dateutil==2.6.1
-requests==2.20.0
+python-dotenv==0.10.2
+requests==2.26.0
 six==1.11.0
 slacker==0.9.60
-urllib3==1.26.5
-python-dotenv==0.10.2
-packaging==19.0
+urllib3==1.26.6


### PR DESCRIPTION
This PR improves the allow and deny lists by turning them into dicts of this structure:

```json
{
  "name": "version"
}
```

Where `version` may be null or a regex version. Additionally, the allowlist has been changed - no longer does the allowlist take precedence, instead the allowlist should be used to pin particular versions of a package. For instance, setting

```json
"allowlist": {
     "Zoom": "9.*"
}
```

pins Zoom to 9.x versions - only they will be promoted. To blanket deny promotion to a pkg, the denylist can be used with a null value (or "all") for version.

Also in this PR I've replaced deprecated methods called on plistlib and logger.