### PR TITLE
Enable `unified_mode` on `cpe_activedirectory`

### DIFF
--- a/chef/cookbooks/cpe_activedirectory/metadata.rb
+++ b/chef/cookbooks/cpe_activedirectory/metadata.rb
@@ -4,6 +4,7 @@ maintainer_email 'it-cpe@gusto.com'
 description 'Using dsconfigad to apply Active Directory settings'
 version '0.1.0'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+chef_version '>= 14.14'
 
 depends 'cpe_utils'
 depends 'uber_helpers'

--- a/chef/cookbooks/cpe_activedirectory/resources/cpe_activedirectory.rb
+++ b/chef/cookbooks/cpe_activedirectory/resources/cpe_activedirectory.rb
@@ -10,6 +10,7 @@
 # This product includes software developed by
 # ZenPayroll, Inc., dba Gusto (https://www.gusto.com/).
 #
+unified_mode true
 
 resource_name :cpe_activedirectory
 provides :cpe_activedirectory, :os => 'darwin'


### PR DESCRIPTION
This PR will solve #54 by enabling `unified_mode` (see: https://docs.chef.io/unified_mode) and setting the cookbook's minimum supported Chef client version to v14.14 (the earliest client version that is able to understand `unified_mode`).