### PR TITLE
Change branch name to main

### DIFF
--- a/autopkg/autopkg_tools.py
+++ b/autopkg/autopkg_tools.py
@@ -180,8 +180,8 @@ def current_branch():
 
 
 def checkout(branch, new=True):
-    if current_branch() != "master" and branch != "master":
-        checkout("master", new=False)
+    if current_branch() != "main" and branch != "main":
+        checkout("main", new=False)
 
     gitcmd = ["checkout"]
     if new:

--- a/autopkg/workflows/autopkg.yml
+++ b/autopkg/workflows/autopkg.yml
@@ -46,7 +46,7 @@ jobs:
         repository: replace_with_your_munki_repo
         token: ${{ secrets.GITHUB_TOKEN }}
         fetch-depth: 1
-        ref: refs/heads/master
+        ref: refs/heads/main
         path: munki_repo
 
     - name: Configure AutoPkg and Git


### PR DESCRIPTION
Hardcoding `master` as the default branch is causing issues now that Github has changed the default branch name to `main`. A more elegant fix should be done, but for now this works.