### PR TITLE
Set a default if _metadata is not present

### DIFF
--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -279,7 +279,7 @@ def promote_pkg(current_plist, path):
         )
         return promoted, result
 
-    last_promoted = plist["_metadata"].get("last_promoted")
+    last_promoted = plist.get("_metadata", {}).get("last_promoted")
     if last_promoted is None:
         logger.debug(f"Package {fullname} has no last_promoted value!")
 


### PR DESCRIPTION
This PR addresses an issue where autopromote fails if there is no `<key>_metadata</key>` dictionary when it tries to promote a package. The new code sets a default value of an empty dictionary if the key cannot be found.