### PR TITLE
Add config options

### DIFF
--- a/autopromote/autopromote.json
+++ b/autopromote/autopromote.json
@@ -33,6 +33,7 @@
 	},
 	"remove_old_catalogs": true,
 	"munki_repo": "munki_repo",
+	"run_makecatalogs": true,
 	"fields_to_copy": [
 		"postinstall_script",
 		"postuninstall_script",

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -454,11 +454,12 @@ def main():
         # Let's do the promoting!
         promotions = promote_pkgs(PKGINFOS_PATHS)
 
-        logger.debug("Calling makecatalogs...")
-        subprocess.call(
-            ["/usr/local/munki/makecatalogs", CONFIG["munki_repo"]],
-            stdout=open(os.devnull, "w"),
-        )
+        if(CONFIG.get("run_makecatalogs", True)):
+            logger.debug("Calling makecatalogs...")
+            subprocess.call(
+                ["/usr/local/munki/makecatalogs", CONFIG["munki_repo"]],
+                stdout=open(os.devnull, "w"),
+            )
     except Exception as e:
         logger.error(e)
         error = e

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -20,7 +20,7 @@ from logging.handlers import RotatingFileHandler
 from logging import StreamHandler
 from collections import OrderedDict
 
-CONFIG_FILE = "/usr/local/munki/autopromote.json"
+CONFIG_FILE = os.getenv("CONFIG_FILE", "/usr/local/munki/autopromote.json")
 PKGINFOS_PATHS = []
 DEBUG = bool(os.environ.get("DEBUG"))
 


### PR DESCRIPTION
These proposed changes allow a little more flexibility in the autopromote script. Both changes default to the old behavior, so no changes are required to continue use of the tool.

You can now set an environment variable declaring the location of `autopromote.json`. Inside that file is a new configuration option that controls whether makecatalogs is run during script execution.