### PR TITLE
Add config options

### DIFF
--- a/autopromote/autopromote.json
+++ b/autopromote/autopromote.json
@@ -54,6 +54,8 @@
 	"force_install_denylist": [],
 	"notify_slack": true,
 	"slack_channel": "#example-slack-channel",
+	"output_results": true,
+	"output_results_path": "results.plist",
 	"logging_level": "DEBUG",
 	"envfile": "~/.autopromote.env",
 	"patch_tuesday": null

--- a/autopromote/autopromote.json
+++ b/autopromote/autopromote.json
@@ -33,6 +33,7 @@
 	},
 	"remove_old_catalogs": true,
 	"munki_repo": "munki_repo",
+	"run_makecatalogs": true,
 	"fields_to_copy": [
 		"postinstall_script",
 		"postuninstall_script",

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -360,6 +360,7 @@ def promote_pkg(current_plist, path):
 
     plist["catalogs"].append(next_catalog)
     promoted = True
+    result["pkginfo"] = path
     result["from"] = latest_catalog
     result["to"] = next_catalog
     plist["_metadata"]["last_promoted"] = arrow.now().datetime

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -432,6 +432,23 @@ def notify_slack(promotions, error):
     )
 
 
+def output_results(promotions, error):
+    """
+    Given a list of results from promote_pkgs, write a file to disk 
+    """
+
+    file_path = CONFIG.get("output_results_path", "results.plist")
+
+    with open(file_path, "wb") as f:
+        if error:
+            plistlib.dump(error, f)
+        else:
+            plistlib.dump([
+                {"fullname": result['fullname'], "from": result['from'], "to": result['to']}
+                for pkg, result in promotions.items()
+            ], f)
+
+
 def main():
     logger.info("\n========================================\n")
     repo = os.path.join(CONFIG["munki_repo"], "pkgsinfo")
@@ -467,6 +484,8 @@ def main():
     finally:
         if CONFIG["notify_slack"]:
             notify_slack(promotions, error)
+        if CONFIG["output_results"]:
+            output_results(promotions, error)
         logging.shutdown()
 
 

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -454,11 +454,12 @@ def main():
         # Let's do the promoting!
         promotions = promote_pkgs(PKGINFOS_PATHS)
 
-        logger.debug("Calling makecatalogs...")
-        subprocess.call(
-            ["/usr/local/munki/makecatalogs", CONFIG["munki_repo"]],
-            stdout=open(os.devnull, "w"),
-        )
+        if CONFIG.get("run_makecatalogs", True):
+            logger.debug("Calling makecatalogs...")
+            subprocess.call(
+                ["/usr/local/munki/makecatalogs", CONFIG["munki_repo"]],
+                stdout=open(os.devnull, "w"),
+            )
     except Exception as e:
         logger.error(e)
         error = e

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -20,7 +20,7 @@ from logging.handlers import RotatingFileHandler
 from logging import StreamHandler
 from collections import OrderedDict
 
-CONFIG_FILE = "/usr/local/munki/autopromote.json"
+CONFIG_FILE = os.getenv("CONFIG_FILE", "/usr/local/munki/autopromote.json")
 PKGINFOS_PATHS = []
 DEBUG = bool(os.environ.get("DEBUG"))
 

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -444,10 +444,7 @@ def output_results(promotions, error):
         if error:
             plistlib.dump(error, f)
         else:
-            plistlib.dump([
-                {"fullname": result['fullname'], "from": result['from'], "to": result['to']}
-                for pkg, result in promotions.items()
-            ], f)
+            plistlib.dump(promotions, f)
 
 
 def main():


### PR DESCRIPTION
These proposed changes allow a little more flexibility in the autopromote script. Both changes default to the old behavior, so no changes are required to continue use of the tool.

You can now set an environment variable declaring the location of `autopromote.json`. Inside that file is a new configuration option that controls whether makecatalogs is run during script execution.

Additionally, this makes it possible to output the results to a file instead of only to Slack.