### PR TITLE
Swap-out `node.macos?`, `node.windows?` for `macos?`, `windows?`

### DIFF
--- a/chef/cookbooks/cpe_activedirectory/README.md
+++ b/chef/cookbooks/cpe_activedirectory/README.md
@@ -130,4 +130,3 @@ node.default['cpe_activedirectory']['unbind'] = true
 Dependencies
 ----------
 * [uber_helpers cookbook](https://github.com/uber/cpe-chef-cookbooks)
-* [cpe_utils cookbook](https://github.com/facebook/IT-CPE)

--- a/chef/cookbooks/cpe_activedirectory/metadata.rb
+++ b/chef/cookbooks/cpe_activedirectory/metadata.rb
@@ -6,5 +6,4 @@ version '0.1.0'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 14.14'
 
-depends 'cpe_utils'
 depends 'uber_helpers'

--- a/chef/cookbooks/cpe_activedirectory/recipes/default.rb
+++ b/chef/cookbooks/cpe_activedirectory/recipes/default.rb
@@ -11,6 +11,6 @@
 # ZenPayroll, Inc., dba Gusto (https://www.gusto.com/).
 #
 
-return unless node.macos?
+return unless macos?
 
 cpe_activedirectory 'Apply cpe_activedirectory'

--- a/chef/cookbooks/cpe_anyconnect/recipes/default.rb
+++ b/chef/cookbooks/cpe_anyconnect/recipes/default.rb
@@ -17,5 +17,5 @@ end
 
 cpe_anyconnect 'Manage Cisco AnyConnect shortcut shim' do
   action :install_shortcut_shim
-  only_if { node.macos? }
+  only_if { macos? }
 end

--- a/chef/cookbooks/cpe_anyconnect/resources/cpe_anyconnect.rb
+++ b/chef/cookbooks/cpe_anyconnect/resources/cpe_anyconnect.rb
@@ -27,9 +27,9 @@ action_class do
   end
 
   def root_dir
-    if node.windows?
+    if windows?
       WINDOWS_DIR
-    elsif node.macos?
+    elsif macos?
       MACOS_DIR
     else
       raise "Unsupported OS"
@@ -37,9 +37,9 @@ action_class do
   end
 
   def server_profile_dir
-    if node.windows?
+    if windows?
       subd = "Profile"
-    elsif node.macos?
+    elsif macos?
       subd = "profile"
     end
 

--- a/chef/cookbooks/cpe_hot_corners/recipes/default.rb
+++ b/chef/cookbooks/cpe_hot_corners/recipes/default.rb
@@ -14,6 +14,6 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-return unless node.macos?
+return unless macos?
 
 cpe_hot_corners 'Apply Hot Corner enforcement'

--- a/chef/cookbooks/cpe_notifications/recipes/default.rb
+++ b/chef/cookbooks/cpe_notifications/recipes/default.rb
@@ -10,7 +10,7 @@
 # ZenPayroll, Inc., dba Gusto (http://www.gusto.com/).
 #
 
-return unless node.macos?
+return unless macos?
 
 # Call the custom resource to handle all of your work
 cpe_notifications 'Apple notification settings' do

--- a/chef/cookbooks/cpe_printers/recipes/default.rb
+++ b/chef/cookbooks/cpe_printers/recipes/default.rb
@@ -10,7 +10,7 @@
 # ZenPayroll, Inc., dba Gusto (http://www.gusto.com/).
 #
 
-return unless node.macos?
+return unless macos?
 
 # Install printers
 cpe_printers "Configure #{node['organization']} printers" do

--- a/chef/cookbooks/cpe_profiles_workspaceone/recipes/default.rb
+++ b/chef/cookbooks/cpe_profiles_workspaceone/recipes/default.rb
@@ -15,7 +15,7 @@
 # Cookbook Name:: cpe_profiles_workspaceone
 # Recipe:: default
 
-return unless node.macos?
+return unless macos?
 
 cpe_profiles_workspaceone 'Managing all MDM configuration profiles via lambda'
 

--- a/chef/cookbooks/cpe_textexpander/recipes/default.rb
+++ b/chef/cookbooks/cpe_textexpander/recipes/default.rb
@@ -11,7 +11,7 @@
 #
 
 # Always gate your recipe to the appropriate OSes!
-return unless node.macos?
+return unless macos?
 
 cpe_textexpander 'Configure textExpander' do
   only_if { node['cpe_textexpander']['configure'] }

--- a/chef/cookbooks/cpe_textexpander/resources/cpe_textexpander.rb
+++ b/chef/cookbooks/cpe_textexpander/resources/cpe_textexpander.rb
@@ -105,7 +105,7 @@ action_class do
 end
 
 action :configure do
-  return unless node.macos?
+  return unless macos?
   return unless node['cpe_textexpander']['configure']
   return if ['_mbsetupuser', 'root'].include? node.console_user
   return unless ::Dir.exists?(settings_dir)

--- a/chef/cookbooks/cpe_yo/recipes/default.rb
+++ b/chef/cookbooks/cpe_yo/recipes/default.rb
@@ -44,7 +44,7 @@
 #   at DateTime.parse('Jan 19 2038 03:14:07')
 # end
 
-return unless node.macos?
+return unless macos?
 
 cpe_yo 'Configure Yo scheduler' do
   action :configure

--- a/chef/node_functions/gusto.rb
+++ b/chef/node_functions/gusto.rb
@@ -76,10 +76,10 @@ class Chef
     end
 
     def encrypted?
-      if node.macos?
+      if macos?
         status = Mixlib::ShellOut.new('/usr/bin/fdesetup isactive')
         status.run_command.stdout.strip.to_s == 'true'
-      elsif node.windows?
+      elsif windows?
         status = powershell_out(
           "Get-BitLockerVolume -MountPoint 'C:' | foreach { $_.VolumeStatus }"
         )
@@ -90,12 +90,12 @@ class Chef
     end
 
     def firewall_enabled?
-      if node.macos?
+      if macos?
         cmd = Mixlib::ShellOut.new(
           '/usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate'
         ).run_command.stdout
         cmd.match?('enabled') ? true : false
-      elsif node.windows?
+      elsif windows?
         cmd = Mixlib::ShellOut.new(
           'sc query MpsSvc | FIND "STATE"'
         ).run_command.stdout
@@ -208,9 +208,9 @@ class Chef
     end
 
     def manufacturer
-      if node.macos?
+      if macos?
         'Apple'
-      elsif node.windows?
+      elsif windows?
         cmd = Mixlib::ShellOut.new('powershell.exe (Get-CimInstance -ClassName Win32_ComputerSystem).Manufacturer')
         cmd.run_command
         cmd.error!


### PR DESCRIPTION
This PR will replace all instances of `node.windows?`, `node.macos?` with `windows?`, `macos?` (respectively).

I recently noticed that Chef has some native helper functions available (See: below code block) for discerning platform family (i.e. `macos?`, `windows?`, `debian?`, `linux?`, et al) that make the corresponding Facebook's helper node functions moot.

```
$ sudo chef-shell
loading configuration: none (standalone session)
true
Session type: standalone
Loading.................done.

Welcome to the chef-shell 17.7.29
For usage see https://docs.chef.io/chef_shell/

run `help' for help, `exit' or ^D to quit.

chef (17.7.29)> require 'pry'
 => true
chef (17.7.29)> binding.pry

Frame number: 0/14
[1] pry(main)> show-method macos?

From: /opt/chef-workstation/embedded/lib/ruby/gems/3.0.0/gems/chef-utils-17.7.29/lib/chef-utils/dsl/platform_family.rb:72:
Owner: ChefUtils::DSL::PlatformFamily
Visibility: public
Signature: macos?(node=?)
Number of lines: 3

def macos?(node = __getnode)
  node ? node["platform_family"] == "mac_os_x" : macos_ruby?
end
[2] pry(main)> show-method windows?

From: /opt/chef-workstation/embedded/lib/ruby/gems/3.0.0/gems/chef-utils-17.7.29/lib/chef-utils/dsl/platform_family.rb:249:
Owner: ChefUtils::DSL::PlatformFamily
Visibility: public
Signature: windows?(node=?)
Number of lines: 13

def windows?(node = __getnode(true))
  # This is all somewhat complicated.  We prefer to get the node object so that chefspec can
  # stub the node object.  But we also have to deal with class-parsing time where there is
  # no node object, so we have to fall back to RUBY_PLATFORM based detection.  We cannot pull
  # the node object out of the Chef.run_context.node global object here (which is what the
  # false flag to __getnode is about) because some run-time code also cannot run under chefspec
  # on non-windows where the node is stubbed to windows.
  #
  # As a result of this the `windows?` helper and the `ChefUtils.windows?` helper do not behave
  # the same way in that the latter is not stubbable by chefspec.
  #
  node ? node["platform_family"] == "windows" : windows_ruby?
end
[3] pry(main)> exit
 => nil
chef (17.7.29)> windows?
 => false
chef (17.7.29)> macos?
 => true
chef (17.7.29)> debian?
 => false
chef (17.7.29)> linux?
 => false
chef (17.7.29)> exit
```