### PR TITLE
Fixed typo that created a second logging instance

### DIFF
--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -394,7 +394,7 @@ def promote_pkgs(pkginfos):
         with open(path, "wb") as f:
             plistlib.dump(result["plist"], f)
 
-        logging.debug(f"wrote {result['fullname']} to {path}")
+        logger.debug(f"wrote {result['fullname']} to {path}")
 
     return promotions
 
@@ -435,7 +435,7 @@ def notify_slack(promotions, error):
 
 def output_results(promotions, error):
     """
-    Given a list of results from promote_pkgs, write a file to disk 
+    Given a list of results from promote_pkgs, write a file to disk
     """
 
     file_path = CONFIG.get("output_results_path", "results.plist")


### PR DESCRIPTION
This change fixes a typo that calls `logging.debug()` directly instead of calling the defined `logger.debug()` method. The typo caused a second, non-configured instance of `logging` to be created and all subsequent messages to be duplicated. The result of this change cleans up the script output and all logging is directed to the defined logger.