### PR TITLE
Don't bind when unbind is true and add force unbind method

### DIFF
--- a/chef/cookbooks/cpe_activedirectory/README.md
+++ b/chef/cookbooks/cpe_activedirectory/README.md
@@ -63,6 +63,7 @@ Binding Options:
 * node['cpe_activedirectory']['bind_options']['ClientID']
 * node['cpe_activedirectory']['bind_options']['HostName']
 * node['cpe_activedirectory']['bind_options']['ADOrganizationalUnit']
+* node['cpe_activedirectory']['force_unbind']
 * node['cpe_activedirectory']['remediate']
 * node['cpe_activedirectory']['unbind']
 * node['cpe_activedirectory']['unbind_method'] (defaults to profile_resource)

--- a/chef/cookbooks/cpe_activedirectory/attributes/default.rb
+++ b/chef/cookbooks/cpe_activedirectory/attributes/default.rb
@@ -61,6 +61,7 @@ default['cpe_activedirectory'] = {
       'useuncpath' => 'Use Windows UNC path for home',
     },
   }.freeze,
+  'force_unbind' => false,
   'options' => {
     'administrative' => {
       'alldomains' => nil, # 'enable' or 'disable' allow authentication from any domain

--- a/chef/cookbooks/cpe_activedirectory/resources/cpe_activedirectory.rb
+++ b/chef/cookbooks/cpe_activedirectory/resources/cpe_activedirectory.rb
@@ -146,6 +146,7 @@ action_class do # rubocop:disable Metrics/BlockLength
     bind_options = node['cpe_activedirectory']['bind_options']
     node['cpe_activedirectory']['options'].each do |root_key, root_subkeys|
       next if root_subkeys.all?(NilClass)
+
       root_subkeys.compact.each do |key, value|
         cmd = "/usr/sbin/dsconfigad -#{key} #{shell_format(value)}"
         if node['cpe_activedirectory']['what_if_execution']

--- a/chef/cookbooks/cpe_activedirectory/resources/cpe_activedirectory.rb
+++ b/chef/cookbooks/cpe_activedirectory/resources/cpe_activedirectory.rb
@@ -18,7 +18,7 @@ default_action :run
 
 action :run do
   unbind if remediate? || unbind?
-  bind if bind?
+  bind if bind? && !unbind?
   configure if configure?
 end
 
@@ -178,9 +178,13 @@ action_class do # rubocop:disable Metrics/BlockLength
     hostname = node['cpe_activedirectory']['bind_ldap_check_hostname']
     port = node['cpe_activedirectory']['bind_ldap_check_port']
     port_timeout = node['cpe_activedirectory']['bind_ldap_check_port_timeout']
+    force_unbind = node['cpe_activedirectory']['force_unbind']
     unless node.port_open?(hostname, port, port_timeout)
-      Chef::Log.warn('cpe_activedirectory cannot communicate to domain - will not attempt to force unbind')
-      return
+      Chef::Log.warn('cpe_activedirectory cannot communicate to domain')
+      unless force_unbind
+        Chef::Log.warn('force unbinding not set - will not attempt to force unbind')
+        return
+      end
     end
 
     if node['cpe_activedirectory']['unbind_method'] == 'profile_resource'


### PR DESCRIPTION
`bind` method runs when `node.default['cpe_activedirectory']['unbind'] = true` is set with `node.default['cpe_activedirectory']['bind'] = true`. this is now fixed

adds `node.default['cpe_activedirectory']['force_unbind'] = true` to not care if the AD domain is reachable.

