### PR TITLE
Replace Slacker with Slack Python SDK

### DIFF
--- a/autopromote/requirements.txt
+++ b/autopromote/requirements.txt
@@ -1,6 +1,6 @@
 arrow==0.12.1
 backports.functools-lru-cache==1.5
-certifi==2018.1.18
+certifi==2021.10.8
 chardet==3.0.4
 charset-normalizer==2.0.4
 idna==2.6
@@ -10,5 +10,5 @@ python-dateutil==2.6.1
 python-dotenv==0.10.2
 requests==2.26.0
 six==1.11.0
-slacker==0.9.60
+slack-sdk==3.16.1
 urllib3==1.26.6


### PR DESCRIPTION
I noticed that [Slacker was archived](https://github.com/os/slacker/commit/3c7f43f75ee838be1121342c1aea1360388015e8), so I wanted to update this to use the Slack provided Python SDK.