### PR TITLE
bump actions/checkout version from 3.0.2 to 3.2.0

### DIFF
--- a/autopkg/workflows/autopkg.yml
+++ b/autopkg/workflows/autopkg.yml
@@ -30,7 +30,7 @@ jobs:
       MUNKI_URL: "https://github.com/munki/munki/releases/download/v5.6.3/munkitools-5.6.3.4401.pkg"
     steps:
     - name: Checkout AutoPkg recipes
-      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2 # Pin SHA1 hash instead of version
+      uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b #v3.2.0 # Pin SHA1 hash instead of version
       with:
         fetch-depth: 1
 
@@ -54,7 +54,7 @@ jobs:
         sudo installer -pkg /tmp/autopkg.pkg -target /
 
     - name: Checkout your Munki LFS repo
-      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
+      uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b #v3.2.0
       with:
         repository: replace_with_your_munki_repo
         # GitHub deploy key with read/write access to repo


### PR DESCRIPTION
Current GitHub Actions are producing warnings:

```
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. 
For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

Bumping actions/checkout version from 3.0.2 to 3.2.0 fixes these warnings.