### PR TITLE
Stop appending .recipe to end of individual recipes

### DIFF
--- a/autopkg/autopkg_tools.py
+++ b/autopkg/autopkg_tools.py
@@ -232,7 +232,7 @@ def handle_recipe(recipe, opts):
 
 def parse_recipes(recipes):
     if RECIPE_TO_RUN:  # Individual recipes, not a run list
-        recipe_list = [recipe for recipe in recipe_list]
+        recipe_list = [recipe for recipe in recipes]
     else:
         ext = os.path.splitext(recipes)[1]
         if ext == ".json":

--- a/autopkg/autopkg_tools.py
+++ b/autopkg/autopkg_tools.py
@@ -231,15 +231,8 @@ def handle_recipe(recipe, opts):
 
 
 def parse_recipes(recipes):
-    recipe_list = []
-    ## Added this section so that we can run individual recipes
-    if RECIPE_TO_RUN:
-        for recipe in recipes:
-            ext = os.path.splitext(recipe)[1]
-            if ext != ".recipe":
-                recipe_list.append(recipe + ".recipe")
-            else:
-                recipe_list.append(recipe)
+    if RECIPE_TO_RUN:  # Individual recipes, not a run list
+        recipe_list = [recipe for recipe in recipe_list]
     else:
         ext = os.path.splitext(recipes)[1]
         if ext == ".json":
@@ -247,7 +240,7 @@ def parse_recipes(recipes):
         elif ext == ".plist":
             parser = plistlib.load
         else:
-            print(f'Invalid run list extension "{ ext }" (expected plist or json)')
+            print(f"Invalid run list extension { ext } (expected plist or json)")
             sys.exit(1)
 
         with open(recipes, "rb") as f:

--- a/autopkg/recipe_list.json
+++ b/autopkg/recipe_list.json
@@ -1,4 +1,3 @@
 [
-	"Firefox.munki.recipe",
-	"Firefox.munki.recipe"
+  "Firefox.munki.recipe"
 ]

--- a/autopkg/workflows/autopkg.yml
+++ b/autopkg/workflows/autopkg.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: # manually triggered
     inputs:
       recipe:
-        description: Optional recipe to run (e.g. Firefox.munki)
+        description: Optional recipe to run (e.g. Firefox.munki.recipe)
         required: false
       debug:
         description: Enable debug


### PR DESCRIPTION
While previously a convenience to not have to use the full recipe filename, it was kind of an odd choice as autopkg does not reference recipes like this. The recipe with `.recipe` is not the true identifier, relative, or absolute path. With YAML recipes often ending in `.yaml`, and there being no standard rule around recipe names - no extension is also valid - let's stop making assumptions around filenames. Only impacts recipes run individually through workflow_dispatch. 

Requires using the full filename when running individual recipes moving forward. This is the same requirement as listing recipes in a run list and standardizes on full filenames. 