### PR TITLE
Fix sub-day auto promotion

### DIFF
--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -26,6 +26,7 @@ from collections import OrderedDict
 CONFIG_FILE = os.getenv("CONFIG_FILE", "/usr/local/munki/autopromote.json")
 PKGINFOS_PATHS = []
 DEBUG = bool(os.environ.get("DEBUG"))
+SECONDS_IN_DAY = 60 * 60 * 24
 
 # Because things get easier if the catalogs are ordered - we don't always need to check "next"
 # in the catalog definition while considering a package for promotion.
@@ -350,7 +351,7 @@ def promote_pkg(current_plist, path):
             f"Channel-shifted promotion period for {fullname} is {channel_shifted}"
         )
         since_last_promotion = arrow.now() - last_promoted
-        days_since_last_promotion = since_last_promotion.days
+        days_since_last_promotion = since_last_promotion.days + since_last_promotion.seconds / SECONDS_IN_DAY
         promotion_due = days_since_last_promotion >= channel_shifted
 
     if not promotion_due:

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -350,8 +350,13 @@ def promote_pkg(current_plist, path):
         logger.debug(
             f"Channel-shifted promotion period for {fullname} is {channel_shifted}"
         )
+
         since_last_promotion = arrow.now() - last_promoted
         days_since_last_promotion = since_last_promotion.days + since_last_promotion.seconds / SECONDS_IN_DAY
+        logger.debug(
+            f"{fullname} was last promoted {days_since_last_promotion} days ago"
+        )
+
         promotion_due = days_since_last_promotion >= channel_shifted
 
     if not promotion_due:

--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -349,7 +349,9 @@ def promote_pkg(current_plist, path):
         logger.debug(
             f"Channel-shifted promotion period for {fullname} is {channel_shifted}"
         )
-        promotion_due = (arrow.now() - last_promoted).days >= channel_shifted
+        since_last_promotion = arrow.now() - last_promoted
+        days_since_last_promotion = since_last_promotion.days
+        promotion_due = days_since_last_promotion >= channel_shifted
 
     if not promotion_due:
         return promoted, result


### PR DESCRIPTION
After waiting ~22 hours for a package to be promoted on Gusto's ultra-fast (i.e. 0.25) channel, I started digging into why.

## Problem
[The logs](https://github.com/Gusto/cpe-autopkg-pipeline/actions/runs/8729344734/job/23951120554#step:10:2251) indicate the `gusto_scope` package was not eligible for promotion. This repo is using [this logic](https://github.com/Gusto/it-cpe-opensource/blob/main/autopromote/autopromote.py#L352) to calculate how many days have passed. It uses [the `days` attribute](https://docs.python.org/3/library/datetime.html#datetime.timedelta.resolution), which represents the whole number of days of a time span **excluding any remaining seconds**:

```python
>>> arrow.now() - last_promoted
datetime.timedelta(seconds=78916, microseconds=943201)

>>> (arrow.now() - last_promoted).days
0
```

Using the existing logic, this package was last promoted 0 days ago, but when considering seconds, it was actually last promoted ~0.91 days ago:

```python
>>> (arrow.now() - last_promoted).seconds / 86400
0.916238425925926
```

This seconds component is essential for quickly promoted packages, that may have a channel shifted promotion period much less than `1.0`.

## Solution
When computing the "days since promotion", include the `seconds` component.