### PR TITLE
fix(autopromote): drop deprecated username/icon_emoji from Slack post

### DIFF
--- a/autopromote/autopromote.py
+++ b/autopromote/autopromote.py
@@ -440,20 +440,22 @@ def notify_slack(promotions, error):
     }
     logger.debug(promotions)
     logger.debug(attachments)
-    # Actually send the Slack message
+    # Actually send the Slack message.
+    # username/icon_emoji per-message overrides were removed because Slack
+    # deprecates them via legacy_custom_bots_deprecated. Configure a custom
+    # display name and avatar on the Slack app's bot user instead.
     try:
-        response = client.chat_postMessage(
+        client.chat_postMessage(
             channel=CONFIG.get("slack_channel", "#test-please-ignore"),
             text="new autopromote.py run complete",
-            username="munki autopromoter",
-            icon_emoji=":munki:",
             attachments=[attachments])
-        assert response["message"]["text"] == "new autopromote.py run complete"
     except SlackApiError as e:
-        # You will get a SlackApiError if "ok" is False
-        assert e.response["ok"] is False
-        assert e.response["error"]  # str like 'invalid_auth', 'channel_not_found'
-        logger.error(f"Slack error: {e.response['error']}")
+        logger.error(
+            f"Slack error (non-fatal, autopromote run succeeded): "
+            f"{e.response.get('error', 'unknown')}"
+        )
+    except Exception as e:
+        logger.error(f"Unexpected Slack error (non-fatal): {e}")
 
 
 def output_results(promotions, error):


### PR DESCRIPTION
## Summary
- Slack rejects `chat.postMessage` calls that include `username` or `icon_emoji` with `legacy_custom_bots_deprecated`; the brittle assertions in the existing `except` block then crashed the workflow with exit 1, blocking prerelease → release Munki promotions on every cron tick since 2026-05-03 (~13 consecutive failures).
- Drop the deprecated parameters and broaden the error handling so any future Slack failure is non-fatal.
- Document in-code why the per-message identity overrides were removed — bot identity is now configurable at the Slack app level.

## Testing
- `python3 -m py_compile autopromote/autopromote.py` clean
- Verified single call site to `notify_slack` and `chat_postMessage`; no other callers/assumptions depend on the removed assertion
- Production validation deferred until merge: monitor next 1-2 scheduled `Autopromote` runs in `cpe-autopkg-pipeline` for success + Slack notification, then confirm fresh `autopromote-YYYY-MM-DD` branches resume in `cpe-munki-lfs`

## Notes for adopters
`it-cpe-opensource` is shared. Other CPE teams using autopromote.py will pick up the fix on their next pull. To preserve a custom display name and avatar, configure the bot user on the Slack app whose token is supplied via \`SLACK_TOKEN\` (App Home → Bot User → Display Name + Avatar). Cosmetic only — skipping just means messages post under the bot's default identity.

## Related
- Ticket: [ITCPE-3434](https://gustohq.atlassian.net/browse/ITCPE-3434)
- Affected workflow: [cpe-autopkg-pipeline:Autopromote](https://github.com/Gusto/cpe-autopkg-pipeline/actions/workflows/autopromote.yml)
- Sample failed run: [25486890409](https://github.com/Gusto/cpe-autopkg-pipeline/actions/runs/25486890409)

[ITCPE-3434]: https://gustohq.atlassian.net/browse/ITCPE-3434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ